### PR TITLE
Fix some type issues in the server interface

### DIFF
--- a/packages/proto-loader/bin/proto-loader-gen-types.ts
+++ b/packages/proto-loader/bin/proto-loader-gen-types.ts
@@ -461,15 +461,15 @@ function generateServiceHandlerInterface(formatter: TextFormatter, serviceType: 
         formatter.writeLine(`${methodName}(call: grpc.ServerDuplexStream<${requestType}, ${responseType}>): void;`);
       } else {
         // Client streaming
-        formatter.writeLine(`${methodName}(call: grpc.ServerReadableStream<${requestType}>, callback: grpc.SendUnaryData<${responseType}>): void;`);
+        formatter.writeLine(`${methodName}(call: grpc.ServerReadableStream<${requestType}>, callback: grpc.sendUnaryData<${responseType}>): void;`);
       }
     } else {
       if (method.responseStream) {
         // Server streaming
-        formatter.writeLine(`${methodName}(call: grpc.ServerWriteableStream<${requestType}, ${responseType}>): void;`);
+        formatter.writeLine(`${methodName}(call: grpc.ServerWritableStream<${requestType}, ${responseType}>): void;`);
       } else {
         // Unary
-        formatter.writeLine(`${methodName}(call: grpc.ServerUnaryCall<${requestType}>, callback: grpc.SendUnaryData<${responseType}>): void;`);
+        formatter.writeLine(`${methodName}(call: grpc.ServerUnaryCall<${requestType}, ${responseType}>, callback: grpc.sendUnaryData<${responseType}>): void;`);
       }
     }
     formatter.writeLine('');


### PR DESCRIPTION
As per https://github.com/grpc/grpc-node/pull/1474#issuecomment-653410625

BTW, unrelated to this change, and quite minor, i'm seeing windows CR characters within `proto-loader-gen-types.ts` and i wonder if they should be converted to unix style line endings? At the least the line-endings should be consistent with other files in this repo. 

<img width="725" alt="Screenshot 2020-07-03 at 09 31 29" src="https://user-images.githubusercontent.com/102141/86449531-384e3f80-bd10-11ea-8308-8aeff8423679.png">
