### PR TITLE
proto-loader: use method descriptor types to define server handlers

### DIFF
--- a/packages/proto-loader/bin/proto-loader-gen-types.ts
+++ b/packages/proto-loader/bin/proto-loader-gen-types.ts
@@ -520,18 +520,18 @@ function generateServiceHandlerInterface(formatter: TextFormatter, serviceType: 
     if (method.requestStream) {
       if (method.responseStream) {
         // Bidi streaming
-        formatter.writeLine(`${methodName}(call: grpc.ServerDuplexStream<${requestType}, ${responseType}>): void;`);
+        formatter.writeLine(`${methodName}: grpc.handleBidiStreamingCall<${requestType}, ${responseType}>;`);
       } else {
         // Client streaming
-        formatter.writeLine(`${methodName}(call: grpc.ServerReadableStream<${requestType}, ${responseType}>, callback: grpc.sendUnaryData<${responseType}>): void;`);
+        formatter.writeLine(`${methodName}: grpc.handleClientStreamingCall<${requestType}, ${responseType}>;`);
       }
     } else {
       if (method.responseStream) {
         // Server streaming
-        formatter.writeLine(`${methodName}(call: grpc.ServerWritableStream<${requestType}, ${responseType}>): void;`);
+        formatter.writeLine(`${methodName}: grpc.handleServerStreamingCall<${requestType}, ${responseType}>;`);
       } else {
         // Unary
-        formatter.writeLine(`${methodName}(call: grpc.ServerUnaryCall<${requestType}, ${responseType}>, callback: grpc.sendUnaryData<${responseType}>): void;`);
+        formatter.writeLine(`${methodName}: grpc.handleUnaryCall<${requestType}, ${responseType}>;`);
       }
     }
     formatter.writeLine('');

--- a/packages/proto-loader/golden-generated/google/longrunning/Operations.ts
+++ b/packages/proto-loader/golden-generated/google/longrunning/Operations.ts
@@ -185,7 +185,7 @@ export interface OperationsHandlers extends grpc.UntypedServiceImplementation {
    * an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
    * corresponding to `Code.CANCELLED`.
    */
-  CancelOperation(call: grpc.ServerUnaryCall<_google_longrunning_CancelOperationRequest__Output, _google_protobuf_Empty>, callback: grpc.sendUnaryData<_google_protobuf_Empty>): void;
+  CancelOperation: grpc.handleUnaryCall<_google_longrunning_CancelOperationRequest__Output, _google_protobuf_Empty>;
   
   /**
    * Deletes a long-running operation. This method indicates that the client is
@@ -193,14 +193,14 @@ export interface OperationsHandlers extends grpc.UntypedServiceImplementation {
    * operation. If the server doesn't support this method, it returns
    * `google.rpc.Code.UNIMPLEMENTED`.
    */
-  DeleteOperation(call: grpc.ServerUnaryCall<_google_longrunning_DeleteOperationRequest__Output, _google_protobuf_Empty>, callback: grpc.sendUnaryData<_google_protobuf_Empty>): void;
+  DeleteOperation: grpc.handleUnaryCall<_google_longrunning_DeleteOperationRequest__Output, _google_protobuf_Empty>;
   
   /**
    * Gets the latest state of a long-running operation.  Clients can use this
    * method to poll the operation result at intervals as recommended by the API
    * service.
    */
-  GetOperation(call: grpc.ServerUnaryCall<_google_longrunning_GetOperationRequest__Output, _google_longrunning_Operation>, callback: grpc.sendUnaryData<_google_longrunning_Operation>): void;
+  GetOperation: grpc.handleUnaryCall<_google_longrunning_GetOperationRequest__Output, _google_longrunning_Operation>;
   
   /**
    * Lists operations that match the specified filter in the request. If the
@@ -214,7 +214,7 @@ export interface OperationsHandlers extends grpc.UntypedServiceImplementation {
    * collection id, however overriding users must ensure the name binding
    * is the parent resource, without the operations collection id.
    */
-  ListOperations(call: grpc.ServerUnaryCall<_google_longrunning_ListOperationsRequest__Output, _google_longrunning_ListOperationsResponse>, callback: grpc.sendUnaryData<_google_longrunning_ListOperationsResponse>): void;
+  ListOperations: grpc.handleUnaryCall<_google_longrunning_ListOperationsRequest__Output, _google_longrunning_ListOperationsResponse>;
   
   /**
    * Waits for the specified long-running operation until it is done or reaches
@@ -227,6 +227,6 @@ export interface OperationsHandlers extends grpc.UntypedServiceImplementation {
    * state before the specified timeout (including immediately), meaning even an
    * immediate response is no guarantee that the operation is done.
    */
-  WaitOperation(call: grpc.ServerUnaryCall<_google_longrunning_WaitOperationRequest__Output, _google_longrunning_Operation>, callback: grpc.sendUnaryData<_google_longrunning_Operation>): void;
+  WaitOperation: grpc.handleUnaryCall<_google_longrunning_WaitOperationRequest__Output, _google_longrunning_Operation>;
   
 }

--- a/packages/proto-loader/golden-generated/google/showcase/v1beta1/Echo.ts
+++ b/packages/proto-loader/golden-generated/google/showcase/v1beta1/Echo.ts
@@ -149,43 +149,43 @@ export interface EchoHandlers extends grpc.UntypedServiceImplementation {
    * and then return the response or error.
    * This method showcases how a client handles delays or retries.
    */
-  Block(call: grpc.ServerUnaryCall<_google_showcase_v1beta1_BlockRequest__Output, _google_showcase_v1beta1_BlockResponse>, callback: grpc.sendUnaryData<_google_showcase_v1beta1_BlockResponse>): void;
+  Block: grpc.handleUnaryCall<_google_showcase_v1beta1_BlockRequest__Output, _google_showcase_v1beta1_BlockResponse>;
   
   /**
    * This method, upon receiving a request on the stream, the same content will
    * be passed  back on the stream. This method showcases bidirectional
    * streaming rpcs.
    */
-  Chat(call: grpc.ServerDuplexStream<_google_showcase_v1beta1_EchoRequest__Output, _google_showcase_v1beta1_EchoResponse>): void;
+  Chat: grpc.handleBidiStreamingCall<_google_showcase_v1beta1_EchoRequest__Output, _google_showcase_v1beta1_EchoResponse>;
   
   /**
    * This method will collect the words given to it. When the stream is closed
    * by the client, this method will return the a concatenation of the strings
    * passed to it. This method showcases client-side streaming rpcs.
    */
-  Collect(call: grpc.ServerReadableStream<_google_showcase_v1beta1_EchoRequest__Output, _google_showcase_v1beta1_EchoResponse>, callback: grpc.sendUnaryData<_google_showcase_v1beta1_EchoResponse>): void;
+  Collect: grpc.handleClientStreamingCall<_google_showcase_v1beta1_EchoRequest__Output, _google_showcase_v1beta1_EchoResponse>;
   
   /**
    * This method simply echos the request. This method is showcases unary rpcs.
    */
-  Echo(call: grpc.ServerUnaryCall<_google_showcase_v1beta1_EchoRequest__Output, _google_showcase_v1beta1_EchoResponse>, callback: grpc.sendUnaryData<_google_showcase_v1beta1_EchoResponse>): void;
+  Echo: grpc.handleUnaryCall<_google_showcase_v1beta1_EchoRequest__Output, _google_showcase_v1beta1_EchoResponse>;
   
   /**
    * This method split the given content into words and will pass each word back
    * through the stream. This method showcases server-side streaming rpcs.
    */
-  Expand(call: grpc.ServerWritableStream<_google_showcase_v1beta1_ExpandRequest__Output, _google_showcase_v1beta1_EchoResponse>): void;
+  Expand: grpc.handleServerStreamingCall<_google_showcase_v1beta1_ExpandRequest__Output, _google_showcase_v1beta1_EchoResponse>;
   
   /**
    * This is similar to the Expand method but instead of returning a stream of
    * expanded words, this method returns a paged list of expanded words.
    */
-  PagedExpand(call: grpc.ServerUnaryCall<_google_showcase_v1beta1_PagedExpandRequest__Output, _google_showcase_v1beta1_PagedExpandResponse>, callback: grpc.sendUnaryData<_google_showcase_v1beta1_PagedExpandResponse>): void;
+  PagedExpand: grpc.handleUnaryCall<_google_showcase_v1beta1_PagedExpandRequest__Output, _google_showcase_v1beta1_PagedExpandResponse>;
   
   /**
    * This method will wait the requested amount of and then return.
    * This method showcases how a client handles a request timing out.
    */
-  Wait(call: grpc.ServerUnaryCall<_google_showcase_v1beta1_WaitRequest__Output, _google_longrunning_Operation>, callback: grpc.sendUnaryData<_google_longrunning_Operation>): void;
+  Wait: grpc.handleUnaryCall<_google_showcase_v1beta1_WaitRequest__Output, _google_longrunning_Operation>;
   
 }


### PR DESCRIPTION
This change will allow for better compatibility with the `grpc` package.

This change should not be merged until this PR is merged: https://github.com/grpc/grpc-node/pull/1587

See: https://github.com/grpc/grpc-node/pull/1474#discussion_r494094017

See: https://github.com/grpc/grpc-node/issues/1581