### PR TITLE
proto-loader: Replace Windows CRLF pair with Unix LF

### DIFF
--- a/packages/proto-loader/bin/proto-loader-gen-types.ts
+++ b/packages/proto-loader/bin/proto-loader-gen-types.ts
@@ -600,7 +600,7 @@ function generateRootFile(formatter: TextFormatter, root: Protobuf.Root, options
   formatter.writeLine(`import type * as grpc from '${options.grpcLib}';`);
   formatter.writeLine("import type { ServiceDefinition, EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-loader';");
   formatter.writeLine('');
-  
+
   generateServiceImports(formatter, root, options);
   formatter.writeLine('');
 


### PR DESCRIPTION
As the title says, this change replaces the windows CRLF pair with a single LF.

<img width="725" alt="Screenshot 2020-07-03 at 09 31 29" src="https://user-images.githubusercontent.com/102141/86449531-384e3f80-bd10-11ea-8308-8aeff8423679.png">

It's a minor change, but makes the line endings consistent with other files in this repo. I also believe a single LF is better for portability across the environments. 