### PR TITLE
proto-loader: Fix yargs types & update README

### DIFF
--- a/packages/proto-loader/README.md
+++ b/packages/proto-loader/README.md
@@ -57,7 +57,7 @@ const options = {
 
 The `proto-loader-gen-types` script distributed with this package can be used to generate TypeScript type information for the objects loaded at runtime. More information about how to use it can be found in [the *@grpc/proto-loader TypeScript Type Generator CLI Tool* proposal document](https://github.com/grpc/proposal/blob/master/L70-node-proto-loader-type-generator.md). The arguments mostly match the `load` function's options; the full usage information is as follows:
 
-```
+```console
 proto-loader-gen-types.js [options] filenames...
 
 Options:
@@ -85,4 +85,33 @@ Options:
   --outDir, -O       Directory in which to output files      [string] [required]
   --grpcLib          The gRPC implementation library that these types will be
                      used with                               [string] [required]
+```
+
+### Example Usage
+
+Generate the types:
+
+```sh
+$(npm bin)/proto-loader-gen-types --longs=String --enums=String --defaults --oneofs --grpcLib=@grpc/grpc-js --outDir=proto/ proto/*.proto
+```
+
+Consume the types:
+
+```ts
+import * as grpc from '@grpc/grpc-js';
+import * as protoLoader from '@grpc/proto-loader';
+import { ProtoGrpcType } from './proto/example';
+import { ExampleHandlers } from './proto/example_package/Example';
+
+const exampleServer: ExampleHandlers = {
+  // server handlers implementation...
+};
+
+const packageDefinition = protoLoader.loadSync('./proto/example.proto');
+const proto = (grpc.loadPackageDefinition(
+  packageDefinition
+) as unknown) as ProtoGrpcType;
+
+const server = new grpc.Server();
+server.addService(proto.example_package.Example.service, exampleServer);
 ```

--- a/packages/proto-loader/bin/proto-loader-gen-types.ts
+++ b/packages/proto-loader/bin/proto-loader-gen-types.ts
@@ -678,6 +678,9 @@ async function writeAllFiles(protoFiles: string[], options: GeneratorOptions) {
 
 function runScript() {
   const argv = yargs
+    .parserConfiguration({
+      'parse-positional-numbers': false
+    })
     .string(['includeDirs', 'grpcLib'])
     .normalize(['includeDirs', 'outDir'])
     .array('includeDirs')
@@ -731,7 +734,7 @@ function runScript() {
       console.log('Parsed arguments:', argv);
     }
     addCommonProtos();
-    writeAllFiles(argv._, {...argv, alternateCommentMode: true}).then(() => {
+    writeAllFiles(argv._ as string[], {...argv, alternateCommentMode: true}).then(() => {
       if (argv.verbose) {
         console.log('Success');
       }


### PR DESCRIPTION
There seems to have been a type update via patch version in `@types/yargs` where `argv._` is now defined as `_: Array<string | number>;`, see:

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/6de1fd533383aa8fcac9460edd2ee5d36989fa7b/types/yargs/index.d.ts#L643

This is why we need to do `argv._ as string[]` as well as add `parse-positional-numbers: false` parser config to prevent yargs from parsing positional args to numbers. ~I need to use `@ts-ignore` because the types for yargs-parser need updating, see: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/50196~

I noticed this as a did a clean clone of this repo follow by a `npm install` and the compile script failed to build.

I also added example usage to the README as I believe this will help with understanding how to use the generator.
